### PR TITLE
User Can Fetch All Olympians

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.4.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'factory_bot_rails'
 gem 'faker'
+gem 'fast_jsonapi'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       railties (>= 4.2.0)
     faker (2.3.0)
       i18n (~> 1.6.0)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -170,6 +172,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   faker
+  fast_jsonapi
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::OlympiansController < ApplicationController
+  def index
+    render json: OlympianSerializer.new(Olympian.all)
+  end
+end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,5 +1,11 @@
 class Api::V1::OlympiansController < ApplicationController
   def index
-    render json: OlympianSerializer.new(Olympian.all)
+    render json: OlympianSerializer.new(
+      Olympian.includes(
+        :team,
+        :events,
+        :sports
+        )
+      )
   end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -8,4 +8,8 @@ class Olympian < ApplicationRecord
   has_many :sports, through: :olympian_sports
 
   enum sex: [ 'M', 'F' ]
+
+  def total_medal_count
+    olympian_events.where.not(medal: 0).count
+  end
 end

--- a/app/serializers/olympian_serializer.rb
+++ b/app/serializers/olympian_serializer.rb
@@ -1,0 +1,13 @@
+class OlympianSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :id,
+             :age,
+             :name,
+             :sports,
+             :team
+
+  attribute :total_medal_count do |object|
+    object.total_medal_count
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/olympians', to: 'olympians#index'
+    end
+  end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,21 @@
 FactoryBot.define do
   factory :event do
+    events = [
+      "Gymnastics Men's Rings",             "Gymnastics Men's Pommelled Horse",
+      "Athletics Women's 5,000 metres",     "Rowing Men's Coxless Pairs",
+      "Taekwondo Women's Flyweight",        "Handball Men's Handball",
+      "Boxing Women's Middleweight",        "Athletics Men's 400 metres",
+      "Handball Women's Handball",          "Cycling Women's Road Race",
+      "Diving Women's Platform",            "Shooting Men's Air Pistol",
+      "Shooting Men's Free Pistol",         "Shooting Women's Air Rifle",
+      "Boxing Men's Lightweight",           "Judo Men's Half-Middleweight",
+      "Weightlifting Women's Middleweight", "Weightlifting Men's Middle-Heavyweight",
+      "Football Men's Football",            "Synchronized Swimming Women's Team",
+      "Judo Men's Extra-Lightweight",       "Wrestling Men's Middleweight, Greco-Roman",
+      "Athletics Men's 10,000 metres",      "Volleyball Women's Volleyball"
+    ]
+
     sport
-    name { "MyString" }
+    name { events.pop }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,20 +1,20 @@
 FactoryBot.define do
-  factory :event do
-    events = [
-      "Gymnastics Men's Rings",             "Gymnastics Men's Pommelled Horse",
-      "Athletics Women's 5,000 metres",     "Rowing Men's Coxless Pairs",
-      "Taekwondo Women's Flyweight",        "Handball Men's Handball",
-      "Boxing Women's Middleweight",        "Athletics Men's 400 metres",
-      "Handball Women's Handball",          "Cycling Women's Road Race",
-      "Diving Women's Platform",            "Shooting Men's Air Pistol",
-      "Shooting Men's Free Pistol",         "Shooting Women's Air Rifle",
-      "Boxing Men's Lightweight",           "Judo Men's Half-Middleweight",
-      "Weightlifting Women's Middleweight", "Weightlifting Men's Middle-Heavyweight",
-      "Football Men's Football",            "Synchronized Swimming Women's Team",
-      "Judo Men's Extra-Lightweight",       "Wrestling Men's Middleweight, Greco-Roman",
-      "Athletics Men's 10,000 metres",      "Volleyball Women's Volleyball"
-    ]
+  events = [
+    "Gymnastics Men's Rings",             "Gymnastics Men's Pommelled Horse",
+    "Athletics Women's 5,000 metres",     "Rowing Men's Coxless Pairs",
+    "Taekwondo Women's Flyweight",        "Handball Men's Handball",
+    "Boxing Women's Middleweight",        "Athletics Men's 400 metres",
+    "Handball Women's Handball",          "Cycling Women's Road Race",
+    "Diving Women's Platform",            "Shooting Men's Air Pistol",
+    "Shooting Men's Free Pistol",         "Shooting Women's Air Rifle",
+    "Boxing Men's Lightweight",           "Judo Men's Half-Middleweight",
+    "Weightlifting Women's Middleweight", "Weightlifting Men's Middle-Heavyweight",
+    "Football Men's Football",            "Synchronized Swimming Women's Team",
+    "Judo Men's Extra-Lightweight",       "Wrestling Men's Middleweight, Greco-Roman",
+    "Athletics Men's 10,000 metres",      "Volleyball Women's Volleyball"
+  ]
 
+  factory :event do
     sport
     name { events.pop }
   end

--- a/spec/factories/olympian_events.rb
+++ b/spec/factories/olympian_events.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     ]
 
     olympian
+    event
     medal { medals.sample }
   end
 end

--- a/spec/factories/olympian_events.rb
+++ b/spec/factories/olympian_events.rb
@@ -1,12 +1,22 @@
 FactoryBot.define do
-  factory :olympian_event do
-    medals = [
-      'Bronze', 'Silver',
-      'Gold',   'NA'
-    ]
+  medals = [
+    'Bronze', 'Silver',
+    'Gold',   'NA'
+  ]
 
+  factory :olympian_event do
     olympian
     event
     medal { medals.sample }
+  end
+
+  factory :olympian_event_with_medal, parent: :olympian_event do
+    medals = medals - ['NA']
+    
+    medal { medals.sample }
+  end
+
+  factory :olympian_event_without_medal, parent: :olympian_event do
+    medal { 'NA' }
   end
 end

--- a/spec/factories/olympians.rb
+++ b/spec/factories/olympians.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
-  factory :olympian do
-    sexes = ["M", "F"]
+  sexes = [ "M", "F" ]
 
+  factory :olympian do
     team
     name { Faker::Name.unique.name }
     sex { sexes.sample }

--- a/spec/factories/sports.rb
+++ b/spec/factories/sports.rb
@@ -4,9 +4,17 @@ FactoryBot.define do
       'Weightlifting', 'Gymnastics',
       'Athletics',     'Rowing',
       'Taekwondo',     'Boxing',
-      'Equestrianism', 'Cycling'
+      'Equestrianism', 'Cycling',
+      'Badminton',     'Rugby Sevens',
+      'Table Tennis',  'Water Polo',
+      'Trampolining',  'Basketball',
+      'Triathlon',     'Modern Pentathlon',
+      'Sailing',       'Beach Volleyball',
+      'Golf',          'Rhythmic Gymnastics',
+      'Hockey',        'Gymnastics',
+      'Archery',       'Tennis'
     ]
 
-    name { sports.sample }
+    name { sports.pop }
   end
 end

--- a/spec/factories/sports.rb
+++ b/spec/factories/sports.rb
@@ -1,20 +1,20 @@
 FactoryBot.define do
-  factory :sport do
-    sports = [
-      'Weightlifting', 'Gymnastics',
-      'Athletics',     'Rowing',
-      'Taekwondo',     'Boxing',
-      'Equestrianism', 'Cycling',
-      'Badminton',     'Rugby Sevens',
-      'Table Tennis',  'Water Polo',
-      'Trampolining',  'Basketball',
-      'Triathlon',     'Modern Pentathlon',
-      'Sailing',       'Beach Volleyball',
-      'Golf',          'Rhythmic Gymnastics',
-      'Hockey',        'Gymnastics',
-      'Archery',       'Tennis'
-    ]
+  sports = [
+    'Weightlifting', 'Gymnastics',
+    'Athletics',     'Rowing',
+    'Taekwondo',     'Boxing',
+    'Equestrianism', 'Cycling',
+    'Badminton',     'Rugby Sevens',
+    'Table Tennis',  'Water Polo',
+    'Trampolining',  'Basketball',
+    'Triathlon',     'Modern Pentathlon',
+    'Sailing',       'Beach Volleyball',
+    'Golf',          'Rhythmic Gymnastics',
+    'Hockey',        'Gymnastics',
+    'Archery',       'Tennis'
+  ]
 
+  factory :sport do
     name { sports.pop }
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -13,4 +13,22 @@ RSpec.describe Olympian, type: :model do
     it { should have_many :olympian_sports }
     it { should have_many(:sports).through(:olympian_sports) }
   end
+
+  describe 'instance methods' do
+    it '#total_medal_count' do
+      o1, o2, o3, o4 = create_list(:olympian, 4)
+
+      create_list(:olympian_event_with_medal, 4, olympian: o2)
+      create_list(:olympian_event_with_medal, 2, olympian: o4)
+      create_list(:olympian_event_with_medal, 1, olympian: o1)
+      create_list(:olympian_event_without_medal, 2, olympian: o4)
+      create_list(:olympian_event_without_medal, 1, olympian: o2)
+      create_list(:olympian_event_without_medal, 0, olympian: o3)
+
+      expect(o1.total_medal_count).to eq(1)
+      expect(o2.total_medal_count).to eq(4)
+      expect(o3.total_medal_count).to eq(0)
+      expect(o4.total_medal_count).to eq(2)
+    end
+  end
 end

--- a/spec/requests/api/v1/olympians_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympians_endpoint_spec.rb
@@ -4,24 +4,33 @@ RSpec.describe 'Olympians endpoint' do
   it 'returns a list of all Olympians' do
     o1, o2, o3, o4 = create_list(:olympian, 4)
 
-    create_list(:olympian_event, 4, olympian: o1)
-    create_list(:olympian_event, 4, olympian: o2)
-    create_list(:olympian_event, 4, olympian: o3)
-    create_list(:olympian_event, 4, olympian: o4)
-
+    create_list(:olympian_event, 3, olympian: o1)
+    create_list(:olympian_event, 3, olympian: o2)
+    create_list(:olympian_event, 3, olympian: o3)
+    create_list(:olympian_event, 3, olympian: o4)
 
     get '/api/v1/olympians'
 
     expect(response).to be_successful
 
     olympians = JSON.parse(response.body, symbolize_names: true)[:data]
+    first_olympian = olympians[0][:attributes]
 
-    expect(olympians.count).to eq(10)
+    expect(olympians.count).to eq(4)
 
-    expect(olympians[0]).to have_key(:age)
-    expect(olympians[0]).to have_key(:name)
-    expect(olympians[0]).to have_key(:sport)
-    expect(olympians[0]).to have_key(:team)
-    expect(olympians[0]).to have_key(:total_medals_won)
+    expect(first_olympian).to have_key(:age)
+    expect(first_olympian[:age]).to be_an(Integer)
+
+    expect(first_olympian).to have_key(:name)
+    expect(first_olympian[:name]).to be_a(String)
+
+    expect(first_olympian).to have_key(:sports)
+    expect(first_olympian[:sports]).to be_an(Array)
+
+    expect(first_olympian).to have_key(:team)
+    expect(first_olympian[:team]).to be_a(Hash)
+
+    expect(first_olympian).to have_key(:total_medal_count)
+    expect(first_olympian[:total_medal_count]).to be_an(Integer)
   end
 end

--- a/spec/requests/api/v1/olympians_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympians_endpoint_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympians endpoint' do
+  it 'returns a list of all Olympians' do
+    o1, o2, o3, o4 = create_list(:olympian, 4)
+
+    create_list(:olympian_event, 4, olympian: o1)
+    create_list(:olympian_event, 4, olympian: o2)
+    create_list(:olympian_event, 4, olympian: o3)
+    create_list(:olympian_event, 4, olympian: o4)
+
+
+    get '/api/v1/olympians'
+
+    expect(response).to be_successful
+
+    olympians = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(olympians.count).to eq(10)
+
+    expect(olympians[0]).to have_key(:age)
+    expect(olympians[0]).to have_key(:name)
+    expect(olympians[0]).to have_key(:sport)
+    expect(olympians[0]).to have_key(:team)
+    expect(olympians[0]).to have_key(:total_medals_won)
+  end
+end


### PR DESCRIPTION
This PR adds the `olympians` endpoint.

**Changes proposed in this pull request:**
* Adds `fast_jsonapi` to Gemfile
* Adds initial spec for `olympians` endpoint
* Adds Olympian#total_medal_count with spec
* Overhauls Event, Sport, Olympian and OlympianEvent factories
* Adds OlympiansController#index with spec
* Adds OlympiansSerializer

Resolves #6 

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)
