### PR TITLE
User Can Fetch Olympians by Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,44 @@
 
 Welcome to _Koroibos_, an API designed to expose endpoints displaying data and statistics from the 2016 Summer Olympic Games. This is the final project for Module 4 at [Turing School of Software & Design](https://turing.io/), completed within a 48-hour timeframe.
 
+## Endpoints
+
+### `GET /api/v1/olympians`
+
+Returns a list of all Olympians in the database, with their name, team, age, sport(s) and total medals won.
+
+Example of expected response:
+```
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "olympian",
+      "attributes": {
+        "id": 1,
+        "age": 22,
+        "name": "Andreea Aanei",
+        "sports": [
+          {
+            "id": 1,
+            "name": "Weightlifting",
+            "created_at": "2019-09-14T23:51:14.066Z",
+            "updated_at": "2019-09-14T23:51:14.066Z"
+          }
+        ],
+        "team": {
+          "id": 1,
+          "name": "Romania",
+          "created_at": "2019-09-14T23:51:14.027Z",
+          "updated_at": "2019-09-14T23:51:14.027Z"
+        },
+        "total_medal_count": 0
+      }
+    }
+  ]
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,11 +1,19 @@
 class Api::V1::OlympiansController < ApplicationController
   def index
-    render json: OlympianSerializer.new(
-      Olympian.includes(
+    if params[:age]
+      if params[:age] == 'youngest'
+        olympian_data = Olympian.youngest_olympian
+      else
+        olympian_data = Olympian.oldest_olympian
+      end
+    else
+      olympian_data = Olympian.includes(
         :team,
         :events,
         :sports
-        )
       )
+    end
+
+    render json: OlympianSerializer.new(olympian_data)
   end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -9,7 +9,19 @@ class Olympian < ApplicationRecord
 
   enum sex: [ 'M', 'F' ]
 
+  default_scope { order(:id) }
+
   def total_medal_count
-    olympian_events.where.not(medal: 0).count
+    olympian_events
+    .where.not(medal: 0)
+    .count
+  end
+
+  def self.youngest_olympian
+    find_by(age: minimum(:age))
+  end
+
+  def self.oldest_olympian
+    find_by(age: maximum(:age))
   end
 end

--- a/db/migrate/20190915045527_add_medal_index_to_olympian_events.rb
+++ b/db/migrate/20190915045527_add_medal_index_to_olympian_events.rb
@@ -1,0 +1,5 @@
+class AddMedalIndexToOlympianEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_index :olympian_events, :medal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_14_211604) do
+ActiveRecord::Schema.define(version: 2019_09_15_045527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2019_09_14_211604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["event_id"], name: "index_olympian_events_on_event_id"
+    t.index ["medal"], name: "index_olympian_events_on_medal"
     t.index ["olympian_id"], name: "index_olympian_events_on_olympian_id"
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,21 +1,6 @@
 FactoryBot.define do
-  events = [
-    "Gymnastics Men's Rings",             "Gymnastics Men's Pommelled Horse",
-    "Athletics Women's 5,000 metres",     "Rowing Men's Coxless Pairs",
-    "Taekwondo Women's Flyweight",        "Handball Men's Handball",
-    "Boxing Women's Middleweight",        "Athletics Men's 400 metres",
-    "Handball Women's Handball",          "Cycling Women's Road Race",
-    "Diving Women's Platform",            "Shooting Men's Air Pistol",
-    "Shooting Men's Free Pistol",         "Shooting Women's Air Rifle",
-    "Boxing Men's Lightweight",           "Judo Men's Half-Middleweight",
-    "Weightlifting Women's Middleweight", "Weightlifting Men's Middle-Heavyweight",
-    "Football Men's Football",            "Synchronized Swimming Women's Team",
-    "Judo Men's Extra-Lightweight",       "Wrestling Men's Middleweight, Greco-Roman",
-    "Athletics Men's 10,000 metres",      "Volleyball Women's Volleyball"
-  ]
-
   factory :event do
     sport
-    name { events.pop }
+    name { Faker::Lorem.words(number: 4) }
   end
 end

--- a/spec/factories/olympian_events.rb
+++ b/spec/factories/olympian_events.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
   factory :olympian_event_with_medal, parent: :olympian_event do
     medals = medals - ['NA']
-    
+
     medal { medals.sample }
   end
 

--- a/spec/factories/sports.rb
+++ b/spec/factories/sports.rb
@@ -1,20 +1,5 @@
 FactoryBot.define do
-  sports = [
-    'Weightlifting', 'Gymnastics',
-    'Athletics',     'Rowing',
-    'Taekwondo',     'Boxing',
-    'Equestrianism', 'Cycling',
-    'Badminton',     'Rugby Sevens',
-    'Table Tennis',  'Water Polo',
-    'Trampolining',  'Basketball',
-    'Triathlon',     'Modern Pentathlon',
-    'Sailing',       'Beach Volleyball',
-    'Golf',          'Rhythmic Gymnastics',
-    'Hockey',        'Canoeing',
-    'Archery',       'Tennis'
-  ]
-
   factory :sport do
-    name { sports.pop }
+    name { Faker::Lorem.words(number: 4) }
   end
 end

--- a/spec/factories/sports.rb
+++ b/spec/factories/sports.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     'Triathlon',     'Modern Pentathlon',
     'Sailing',       'Beach Volleyball',
     'Golf',          'Rhythmic Gymnastics',
-    'Hockey',        'Gymnastics',
+    'Hockey',        'Canoeing',
     'Archery',       'Tennis'
   ]
 

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -31,4 +31,22 @@ RSpec.describe Olympian, type: :model do
       expect(o4.total_medal_count).to eq(2)
     end
   end
+
+  describe 'class methods' do
+    it '.youngest_olympian' do
+      create_list(:olympian, 4)
+
+      youngest_olympian = create(:olympian, age: 14)
+
+      expect(Olympian.youngest_olympian).to eq(youngest_olympian)
+    end
+
+    it '.oldest_olympian' do
+      create_list(:olympian, 4)
+      
+      oldest_olympian = create(:olympian, age: 42)
+
+      expect(Olympian.oldest_olympian).to eq(oldest_olympian)
+    end
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Olympian, type: :model do
+  before :each do
+    @o1, @o2, @o3, @o4 = create_list(:olympian, 4)
+    @o5 = create(:olympian, age: 14)
+    @o6 = create(:olympian, age: 42)
+
+    create_list(:olympian_event_with_medal, 4, olympian: @o2)
+    create_list(:olympian_event_with_medal, 2, olympian: @o4)
+    create_list(:olympian_event_with_medal, 1, olympian: @o1)
+    create_list(:olympian_event_without_medal, 2, olympian: @o4)
+    create_list(:olympian_event_without_medal, 1, olympian: @o2)
+    create_list(:olympian_event_without_medal, 0, olympian: @o3)
+  end
+
   describe 'validations' do
     it { should validate_presence_of :name }
     it { should validate_uniqueness_of :name }
@@ -16,37 +29,20 @@ RSpec.describe Olympian, type: :model do
 
   describe 'instance methods' do
     it '#total_medal_count' do
-      o1, o2, o3, o4 = create_list(:olympian, 4)
-
-      create_list(:olympian_event_with_medal, 4, olympian: o2)
-      create_list(:olympian_event_with_medal, 2, olympian: o4)
-      create_list(:olympian_event_with_medal, 1, olympian: o1)
-      create_list(:olympian_event_without_medal, 2, olympian: o4)
-      create_list(:olympian_event_without_medal, 1, olympian: o2)
-      create_list(:olympian_event_without_medal, 0, olympian: o3)
-
-      expect(o1.total_medal_count).to eq(1)
-      expect(o2.total_medal_count).to eq(4)
-      expect(o3.total_medal_count).to eq(0)
-      expect(o4.total_medal_count).to eq(2)
+      expect(@o1.total_medal_count).to eq(1)
+      expect(@o2.total_medal_count).to eq(4)
+      expect(@o3.total_medal_count).to eq(0)
+      expect(@o4.total_medal_count).to eq(2)
     end
   end
 
   describe 'class methods' do
     it '.youngest_olympian' do
-      create_list(:olympian, 4)
-
-      youngest_olympian = create(:olympian, age: 14)
-
-      expect(Olympian.youngest_olympian).to eq(youngest_olympian)
+      expect(Olympian.youngest_olympian).to eq(@o5)
     end
 
     it '.oldest_olympian' do
-      create_list(:olympian, 4)
-      
-      oldest_olympian = create(:olympian, age: 42)
-
-      expect(Olympian.oldest_olympian).to eq(oldest_olympian)
+      expect(Olympian.oldest_olympian).to eq(@o6)
     end
   end
 end

--- a/spec/requests/api/v1/olympians_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympians_endpoint_spec.rb
@@ -1,14 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'Olympians endpoint' do
+  before :each do
+    @o1, @o2, @o3, @o4 = create_list(:olympian, 4)
+    @o5 = create(:olympian, age: 14)
+    @o6 = create(:olympian, age: 42)
+
+    create_list(:olympian_event, 3, olympian: @o1)
+    create_list(:olympian_event, 3, olympian: @o2)
+    create_list(:olympian_event, 3, olympian: @o3)
+    create_list(:olympian_event, 3, olympian: @o4)
+  end
+
   it 'returns a list of all Olympians' do
-    o1, o2, o3, o4 = create_list(:olympian, 4)
-
-    create_list(:olympian_event, 3, olympian: o1)
-    create_list(:olympian_event, 3, olympian: o2)
-    create_list(:olympian_event, 3, olympian: o3)
-    create_list(:olympian_event, 3, olympian: o4)
-
     get '/api/v1/olympians'
 
     expect(response).to be_successful
@@ -16,7 +20,7 @@ RSpec.describe 'Olympians endpoint' do
     olympians = JSON.parse(response.body, symbolize_names: true)[:data]
     first_olympian = olympians[0][:attributes]
 
-    expect(olympians.count).to eq(4)
+    expect(olympians.count).to eq(6)
 
     expect(first_olympian).to have_key(:age)
     expect(first_olympian[:age]).to be_an(Integer)
@@ -32,5 +36,15 @@ RSpec.describe 'Olympians endpoint' do
 
     expect(first_olympian).to have_key(:total_medal_count)
     expect(first_olympian[:total_medal_count]).to be_an(Integer)
+  end
+
+  it 'returns the youngest Olympian' do
+    get '/api/v1/olympians?age=youngest'
+
+    expect(response).to be_successful
+
+    olympian = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+    expect(olympian[:age]).to eq(14)
   end
 end

--- a/spec/requests/api/v1/olympians_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympians_endpoint_spec.rb
@@ -47,4 +47,14 @@ RSpec.describe 'Olympians endpoint' do
 
     expect(olympian[:age]).to eq(14)
   end
+
+  it 'returns the oldest Olympian' do
+    get '/api/v1/olympians?age=oldest'
+
+    expect(response).to be_successful
+
+    olympian = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+    expect(olympian[:age]).to eq(42)
+  end
 end


### PR DESCRIPTION
This PR adds the ability to fetch the oldest and youngest olympians from the database.

**Changes proposed in this pull request:**
* Adds Olympian.youngest_olympian and Olympian.oldest_olympian with specs
* Adds spec for passing `olympian?age=youngest` and `olympian?age=oldest` to OlympiansController
* Adds conditional logic for filtering oldest/youngest Olympian to OlympiansController

Resolves #7, Resolves #8

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)
