### PR TITLE
User Can Fetch Olympian Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,66 @@ Example of expected response:
 }
 ```
 
+Also accepts the query param `age`. `?age=youngest` will return the youngest Olympian (example below), while `?age=oldest` will return the oldest Olympian.
+
+Example of expected response:
+```
+{
+  "data": {
+    "id": "2190",
+    "type": "olympian",
+    "attributes": {
+      "id": 2190,
+      "age": 13,
+      "name": "Ana Iulia Dascl",
+      "sports": [
+        {
+          "id": 18,
+          "name": "Swimming",
+          "created_at": "2019-09-14T23:51:15.082Z",
+          "updated_at": "2019-09-14T23:51:15.082Z"
+        }
+      ],
+      "team": {
+        "id": 1,
+        "name": "Romania",
+        "created_at": "2019-09-14T23:51:14.027Z",
+        "updated_at": "2019-09-14T23:51:14.027Z"
+      },
+      "total_medal_count": 0
+    }
+  }
+}
+```
+
+### `GET /api/v1/olympian_stats`
+
+Returns statistics for all Olympians, such as total Olympic competitors, average height, weight and age.
+
+Example of expected response:
+```
+{
+  "data": {
+    "id": null,
+    "type": "olympian_stats",
+    "attributes": {
+      "total_competing_olympians": 2850,
+      "average_age": "26.37",
+      "average_height": {
+        "unit": "cm",
+        "female_olympians": "179.52",
+        "male_olympians": "167.2"
+      },
+      "average_weight": {
+        "unit": "kg",
+        "female_olympians": "77.87",
+        "male_olympians": "61.41"
+      }
+    }
+  }
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::OlympianStatsController < ApplicationController
+  def index
+    facade = OlympianStatFacade.new
+    render json: OlympianStatSerializer.new(facade.olympian_stats)
+  end
+end

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::OlympianStatsController < ApplicationController
   def index
-    facade = OlympianStatFacade.new
-    render json: OlympianStatSerializer.new(facade.olympian_stats)
+    render json: OlympianStatSerializer.new(OlympianStatFacade.new)
   end
 end

--- a/app/facades/olympian_stat_facade.rb
+++ b/app/facades/olympian_stat_facade.rb
@@ -11,7 +11,6 @@ class OlympianStatFacade
 
   def average_height
     {
-      unit: 'cm',
       female_olympians: Olympian.olympian_average('height', 'F'),
       male_olympians: Olympian.olympian_average('height', 'M')
     }
@@ -19,7 +18,6 @@ class OlympianStatFacade
 
   def average_weight
     {
-      unit: 'kg',
       female_olympians: Olympian.olympian_average('weight', 'F'),
       male_olympians: Olympian.olympian_average('weight', 'M')
     }

--- a/app/facades/olympian_stat_facade.rb
+++ b/app/facades/olympian_stat_facade.rb
@@ -1,0 +1,31 @@
+class OlympianStatFacade
+  attr_reader :id
+
+  def initialize
+    @id = nil
+  end
+
+  def total_competing_olympians
+    Olympian.total_competing_olympians
+  end
+
+  def average_height
+    {
+      unit: 'cm',
+      female_olympians: Olympian.olympian_average('height', 'F'),
+      male_olympians: Olympian.olympian_average('height', 'M')
+    }
+  end
+
+  def average_weight
+    {
+      unit: 'kg',
+      female_olympians: Olympian.olympian_average('weight', 'F'),
+      male_olympians: Olympian.olympian_average('weight', 'M')
+    }
+  end
+
+  def average_age
+    Olympian.olympian_average('age', [ 'F', 'M' ])
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -24,4 +24,13 @@ class Olympian < ApplicationRecord
   def self.oldest_olympian
     find_by(age: maximum(:age))
   end
+
+  def self.total_competing_olympians
+    Olympian.count
+  end
+
+  def self.olympian_average(attribute, gender)
+    where(sex: gender)
+    .average(attribute)
+  end
 end

--- a/app/serializers/olympian_stat_serializer.rb
+++ b/app/serializers/olympian_stat_serializer.rb
@@ -1,0 +1,10 @@
+class OlympianStatSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :olympian_stats
+  set_id :id
+
+  attributes :total_competing_olympians,
+             :average_height,
+             :average_weight,
+             :average_age
+end

--- a/app/serializers/olympian_stat_serializer.rb
+++ b/app/serializers/olympian_stat_serializer.rb
@@ -3,8 +3,25 @@ class OlympianStatSerializer
   set_type :olympian_stats
   set_id :id
 
-  attributes :total_competing_olympians,
-             :average_height,
-             :average_weight,
-             :average_age
+  attribute :total_competing_olympians
+
+  attribute :average_age do |object|
+    object.average_age.round(2)
+  end
+
+  attribute :average_height do |object|
+    {
+      unit: 'cm',
+      female_olympians: object.average_height[:female_olympians].round(2),
+      male_olympians: object.average_height[:male_olympians].round(2)
+    }
+  end
+
+  attribute :average_weight do |object|
+    {
+      unit: 'kg',
+      female_olympians: object.average_weight[:female_olympians].round(2),
+      male_olympians: object.average_weight[:male_olympians].round(2)
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#index'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -2,9 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Olympian, type: :model do
   before :each do
-    @o1, @o2, @o3, @o4 = create_list(:olympian, 4)
-    @o5 = create(:olympian, age: 14)
-    @o6 = create(:olympian, age: 42)
+    @o1 = create(:olympian, sex: 'F', age: 14, height: 160, weight: 60)
+    @o2 = create(:olympian, sex: 'F', age: 20, height: 165, weight: 65)
+    @o3 = create(:olympian, sex: 'F', age: 25, height: 170, weight: 70)
+    @o4 = create(:olympian, sex: 'F', age: 30, height: 175, weight: 75)
+    @o5 = create(:olympian, sex: 'M', age: 25, height: 160, weight: 75)
+    @o6 = create(:olympian, sex: 'M', age: 30, height: 185, weight: 80)
+    @o7 = create(:olympian, sex: 'M', age: 30, height: 200, weight: 85)
+    @o8 = create(:olympian, sex: 'M', age: 42, height: 205, weight: 100)
 
     create_list(:olympian_event_with_medal, 4, olympian: @o2)
     create_list(:olympian_event_with_medal, 2, olympian: @o4)
@@ -38,11 +43,25 @@ RSpec.describe Olympian, type: :model do
 
   describe 'class methods' do
     it '.youngest_olympian' do
-      expect(Olympian.youngest_olympian).to eq(@o5)
+      expect(Olympian.youngest_olympian).to eq(@o1)
     end
 
     it '.oldest_olympian' do
-      expect(Olympian.oldest_olympian).to eq(@o6)
+      expect(Olympian.oldest_olympian).to eq(@o8)
+    end
+
+    it '.total_competing_olympians' do
+      expect(Olympian.total_competing_olympians).to eq(8)
+    end
+
+    it '.olympian_average' do
+      expect(Olympian.olympian_average('height', 'F')).to eq(167.5)
+      expect(Olympian.olympian_average('height', 'M')).to eq(187.5)
+
+      expect(Olympian.olympian_average('weight', 'F')).to eq(67.5)
+      expect(Olympian.olympian_average('weight', 'M')).to eq(85)
+
+      expect(Olympian.olympian_average('age', [ 'F', 'M' ])).to eq(27)
     end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_endpoint_spec.rb
@@ -17,36 +17,19 @@ RSpec.describe 'Olympian stats endpoint' do
 
     expect(response).to be_successful
 
-    olympian_stats = JSON.parse(response.body, symbolize_names: true)[:data]
+    olympian_stats = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
     olympian_average_height = olympian_stats[:average_height]
     olympian_average_weight = olympian_stats[:average_weight]
 
     expect(olympian_stats[:total_competing_olympians]).to eq(8)
-    expect(olympian_stats[:average_age]).to eq(26.25)
+    expect(olympian_stats[:average_age]).to eq('26.25')
 
     expect(olympian_average_height[:unit]).to eq('cm')
-    expect(olympian_average_height[:female_olympians]).to eq(167.5)
-    expect(olympian_average_height[:male_olympians]).to eq(187.5)
+    expect(olympian_average_height[:female_olympians]).to eq('167.5')
+    expect(olympian_average_height[:male_olympians]).to eq('187.5')
 
     expect(olympian_average_weight[:unit]).to eq('kg')
-    expect(olympian_average_weight[:female_olympians]).to eq(67.5)
-    expect(olympian_average_weight[:male_olympians]).to eq(85)
+    expect(olympian_average_weight[:female_olympians]).to eq('67.5')
+    expect(olympian_average_weight[:male_olympians]).to eq('85.0')
   end
 end
-
-
-
-
-
-
-# {
-#    "olympian_stats": {
-#      "total_competing_olympians": 3120
-#      "average_weight:" {
-#        "unit": "kg",
-#        "male_olympians": 75.4,
-#        "female_olympians": 70.2
-#      }
-#      "average_age:" 26.2
-#    }
-#  }

--- a/spec/requests/api/v1/olympian_stats_endpoint_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_endpoint_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympian stats endpoint' do
+  before :each do
+    @o1 = create(:olympian, sex: 'F', age: 15, height: 160, weight: 60)
+    @o2 = create(:olympian, sex: 'F', age: 20, height: 165, weight: 65)
+    @o3 = create(:olympian, sex: 'F', age: 25, height: 170, weight: 70)
+    @o4 = create(:olympian, sex: 'F', age: 30, height: 175, weight: 75)
+    @o5 = create(:olympian, sex: 'M', age: 25, height: 160, weight: 75)
+    @o6 = create(:olympian, sex: 'M', age: 30, height: 185, weight: 80)
+    @o7 = create(:olympian, sex: 'M', age: 30, height: 200, weight: 85)
+    @o8 = create(:olympian, sex: 'M', age: 35, height: 205, weight: 100)
+  end
+
+  it 'returns stats on all Olympians' do
+    get '/api/v1/olympian_stats'
+
+    expect(response).to be_successful
+
+    olympian_stats = JSON.parse(response.body, symbolize_names: true)[:data]
+    olympian_average_height = olympian_stats[:average_height]
+    olympian_average_weight = olympian_stats[:average_weight]
+
+    expect(olympian_stats[:total_competing_olympians]).to eq(8)
+    expect(olympian_stats[:average_age]).to eq(26.25)
+
+    expect(olympian_average_height[:unit]).to eq('cm')
+    expect(olympian_average_height[:female_olympians]).to eq(167.5)
+    expect(olympian_average_height[:male_olympians]).to eq(187.5)
+
+    expect(olympian_average_weight[:unit]).to eq('kg')
+    expect(olympian_average_weight[:female_olympians]).to eq(67.5)
+    expect(olympian_average_weight[:male_olympians]).to eq(85)
+  end
+end
+
+
+
+
+
+
+# {
+#    "olympian_stats": {
+#      "total_competing_olympians": 3120
+#      "average_weight:" {
+#        "unit": "kg",
+#        "male_olympians": 75.4,
+#        "female_olympians": 70.2
+#      }
+#      "average_age:" 26.2
+#    }
+#  }


### PR DESCRIPTION
This PR adds the Olympian stats endpoint.

**Changes proposed in this pull request:**
* Adds spec for Olympian stats endpoint
* Adds Olympian.total_competing_olympians and .olympian_average with specs
* Adds OlympianStatsController#index with route
* Adds OlympianStatSerializer and facade

Resolves #9 

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)
