### PR TITLE
User Can Fetch Events by Sport

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,42 @@ Example of expected response:
 }
 ```
 
+### `GET /api/v1/events`
+
+Returns a list of all events, broken down by sport.
+
+Example of expected output:
+```
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "sport",
+      "attributes": {
+          "name": "Weightlifting",
+          "events": [
+            "Weightlifting Women's Super-Heavyweight",
+            "Weightlifting Men's Heavyweight",
+            "Weightlifting Men's Middleweight",
+            "Weightlifting Men's Middle-Heavyweight",
+            "Weightlifting Men's Featherweight",
+            "Weightlifting Women's Flyweight",
+            "Weightlifting Women's Middleweight",
+            "Weightlifting Women's Lightweight",
+            "Weightlifting Men's Lightweight",
+            "Weightlifting Men's Super-Heavyweight",
+            "Weightlifting Men's Light-Heavyweight",
+            "Weightlifting Women's Heavyweight",
+            "Weightlifting Women's Light-Heavyweight",
+            "Weightlifting Men's Bantamweight",
+            "Weightlifting Women's Featherweight"
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::EventsController < ApplicationController
+  def index
+    render json: SportSerializer.new(Sport.includes(:events))
+  end
+end

--- a/app/models/sport.rb
+++ b/app/models/sport.rb
@@ -1,6 +1,7 @@
 class Sport < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
+  has_many :events
   has_many :olympian_sports
   has_many :olympians, through: :olympian_sports
 end

--- a/app/serializers/sport_serializer.rb
+++ b/app/serializers/sport_serializer.rb
@@ -1,0 +1,11 @@
+class SportSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name
+
+  attribute :events do |object|
+    object.events.map do |event|
+      event.name
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      get '/events', to: 'events#index'
       get '/olympians', to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#index'
     end

--- a/spec/models/sport_spec.rb
+++ b/spec/models/sport_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Sport, type: :model do
   end
 
   describe 'relationships' do
+    it { should have_many :events }
     it { should have_many :olympian_sports }
     it { should have_many(:olympians).through(:olympian_sports) }
   end

--- a/spec/requests/api/v1/events_endpoint_spec.rb
+++ b/spec/requests/api/v1/events_endpoint_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'events endpoint spec' do
+  it 'returns all events broken down by sport' do
+    s1, s2, s3, s4 = create_list(:sport, 4)
+
+    create(:event, sport: s1)
+    create(:event, sport: s1)
+    create(:event, sport: s2)
+    create(:event, sport: s2)
+    create(:event, sport: s3)
+    create(:event, sport: s3)
+    create(:event, sport: s4)
+    create(:event, sport: s4)
+
+    get '/api/v1/events'
+
+    events_by_sport = JSON.parse(response.body, symbolize_names: true)[:data]
+    first_sport_event = events_by_sport[0][:attributes]
+
+    expect(events_by_sport.count).to eq(4)
+
+    expect(first_sport_event).to have_key(:name)
+    expect(first_sport_event[:events]).to be_an(Array)
+    expect(first_sport_event[:events].count).to eq(2)
+  end
+end


### PR DESCRIPTION
This PR adds the `events` endpoint, which returns all events broken down by sport.

**Changes proposed in this pull request:**
* Adds Sport - Event relationship and spec
* Adds `events` endpoint spec
* Adds EventsController#index with route
* Adds SportSerializer
* Updates README to include `events` endpoint documentation

Resolves #10 

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)

**Notes:**
* This endpoint is odd. The EventsController calls a SportSerializer to return the requested information. Given that what we're looking for is events by sport, it could make more sense to call this a `sports` endpoint.
