### PR TITLE
User Can Fetch Medalists by Sport

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,47 @@ Example of expected output:
 }
 ```
 
+### `GET /api/v1/medalists`
+
+Returns a list of all medalists, broken down by event.
+
+Example of expected response:
+```
+{
+  "data": {
+    "id": null,
+    "type": "events",
+    "attributes": {
+      "event_medalists": [
+        {
+          "event": "Rowing Men's Coxless Pairs",
+          "medalists": [
+            {
+              "name": "Giovanni Abagnale",
+              "team": "Italy",
+              "age": 21,
+              "medal": "Bronze"
+            },
+            {
+              "name": "Hamish Byron Bond",
+              "team": "New Zealand",
+              "age": 30,
+              "medal": "Gold"
+            },
+            {
+              "name": "Lawrence Brittain",
+              "team": "South Africa",
+              "age": 25,
+              "medal": "Silver"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/medalists_controller.rb
+++ b/app/controllers/api/v1/medalists_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::MedalistsController < ApplicationController
+  def index
+    events = Event.all
+    facade = MedalistFacade.new(events)
+    render json: MedalistSerializer.new(facade)
+  end
+end

--- a/app/facades/medalist_facade.rb
+++ b/app/facades/medalist_facade.rb
@@ -1,0 +1,44 @@
+class MedalistFacade
+  attr_reader :id
+
+  def initialize(events)
+    @id = nil
+    @events = events
+  end
+
+  def event_medalists
+    @events.map do |event|
+      medalists = medalists_by_event(event.id)
+
+      {
+        event: event.name,
+        medalists: format_medalists(medalists)
+      }
+    end
+  end
+
+  private
+
+  def format_medalists(medalists)
+    medalists.map do |medalist|
+      {
+        name: medalist.name,
+        team: medalist.team.name,
+        age: medalist.age,
+        medal:
+          case medalist.medal
+          when 1
+            'Bronze'
+          when 2
+            'Silver'
+          when 3
+            'Gold'
+          end
+      }
+    end
+  end
+
+  def medalists_by_event(event_id)
+    Olympian.event_medalists(event_id)
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -33,4 +33,11 @@ class Olympian < ApplicationRecord
     where(sex: gender)
     .average(attribute)
   end
+
+  def self.event_medalists(event_id)
+    select('olympians.*, olympian_events.medal AS medal')
+    .joins(:events)
+    .where('events.id = ?', event_id)
+    .where.not('olympian_events.medal = ?', 0)
+  end
 end

--- a/app/serializers/medalist_serializer.rb
+++ b/app/serializers/medalist_serializer.rb
@@ -1,0 +1,7 @@
+class MedalistSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :events
+  set_id :id
+
+  attributes :event_medalists
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/events', to: 'events#index'
+      get '/medalists', to: 'medalists#index'
       get '/olympians', to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#index'
     end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -11,12 +11,17 @@ RSpec.describe Olympian, type: :model do
     @o7 = create(:olympian, sex: 'M', age: 30, height: 200, weight: 85)
     @o8 = create(:olympian, sex: 'M', age: 42, height: 205, weight: 100)
 
-    create_list(:olympian_event_with_medal, 4, olympian: @o2)
-    create_list(:olympian_event_with_medal, 2, olympian: @o4)
-    create_list(:olympian_event_with_medal, 1, olympian: @o1)
-    create_list(:olympian_event_without_medal, 2, olympian: @o4)
-    create_list(:olympian_event_without_medal, 1, olympian: @o2)
-    create_list(:olympian_event_without_medal, 0, olympian: @o3)
+    @e1 = create(:event, name: 'Event 1')
+    @e2 = create(:event, name: 'Event 2')
+    @e3 = create(:event, name: 'Event 3')
+    @e4 = create(:event, name: 'Event 4')
+
+    create_list(:olympian_event_with_medal, 4, event: @e1, olympian: @o2)
+    create_list(:olympian_event_with_medal, 2, event: @e1, olympian: @o4)
+    create_list(:olympian_event_with_medal, 1, event: @e2, olympian: @o1)
+    create_list(:olympian_event_without_medal, 2, event: @e2, olympian: @o4)
+    create_list(:olympian_event_without_medal, 1, event: @e3, olympian: @o2)
+    create_list(:olympian_event_without_medal, 0, event: @e4, olympian: @o3)
   end
 
   describe 'validations' do
@@ -62,6 +67,11 @@ RSpec.describe Olympian, type: :model do
       expect(Olympian.olympian_average('weight', 'M')).to eq(85)
 
       expect(Olympian.olympian_average('age', [ 'F', 'M' ])).to eq(27)
+    end
+
+    it '.medalists_by_event' do
+      expect(Olympian.event_medalists(@e1.id)).to eq([@o2, @o2, @o2, @o2, @o4, @o4])
+      expect(Olympian.event_medalists(@e2.id)).to eq([@o1])
     end
   end
 end

--- a/spec/requests/api/v1/medalists_endpoint_spec.rb
+++ b/spec/requests/api/v1/medalists_endpoint_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'medalists endpoint' do
+  it 'returns a list of all medalists broken down by event' do
+    o1, o2, o3, o4 = create_list(:olympian, 4)
+
+    e1 = create(:event, name: 'Event 1')
+    e2 = create(:event, name: 'Event 2')
+    e3 = create(:event, name: 'Event 3')
+    e4 = create(:event, name: 'Event 4')
+
+    create(:olympian_event_with_medal, event: e1, olympian: o1)
+    create(:olympian_event_with_medal, event: e1, olympian: o2)
+    create(:olympian_event_with_medal, event: e2, olympian: o1)
+    create(:olympian_event_with_medal, event: e2, olympian: o2)
+    create(:olympian_event_with_medal, event: e3, olympian: o3)
+    create(:olympian_event_with_medal, event: e4, olympian: o4)
+
+    get '/api/v1/medalists'
+
+    events = JSON.parse(response.body, symbolize_names: true)[:data][:attributes][:event_medalists]
+    event = events[0]
+    first_event_medalists = event[:medalists][0]
+
+    expect(events.count).to eq(4)
+    expect(event).to have_key(:event)
+
+    expect(first_event_medalists).to have_key(:name)
+    expect(first_event_medalists).to have_key(:team)
+    expect(first_event_medalists).to have_key(:age)
+    expect(first_event_medalists).to have_key(:medal)
+  end
+end


### PR DESCRIPTION
This PR adds a `medalists` endpoint that returns all medalists, grouped by event.

**Changes proposed in this pull request:**
* Adds `medalist` endpoint spec
* Adds MedalistsController#index with route
* Adds MedalistsFacade and Serializer
* Adds Olympian.event_medalists with spec
* Adds medalist endpoint documentation to README

Resolves #11 

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)
