### PR TITLE
User Can Fetch Total Medals by Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,42 @@ Example of expected response:
 }
 ```
 
+### `GET /api/v1/medal_count`
+
+Returns a list of teams with their associated medal counts.
+
+Example of expected response:
+```
+{
+  "data": {
+    "id": null,
+    "type": "teams",
+    "attributes": {
+      "team_medalists": [
+        {
+          "team": "Romania",
+          "total_medal_count": 7,
+          "medals": {
+              "bronze": 5,
+              "silver": 0,
+              "gold": 2
+          }
+        },
+        {
+          "team": "Spain",
+          "total_medal_count": 14,
+          "medals": {
+              "bronze": 6,
+              "silver": 4,
+              "gold": 4
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/medal_count_controller.rb
+++ b/app/controllers/api/v1/medal_count_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::MedalCountController < ApplicationController
+  def index
+    teams = Team.all
+    facade = MedalCountFacade.new(teams)
+    render json: MedalCountSerializer.new(facade)
+  end
+end

--- a/app/facades/medal_count_facade.rb
+++ b/app/facades/medal_count_facade.rb
@@ -1,0 +1,22 @@
+class MedalCountFacade
+  attr_reader :id
+
+  def initialize(teams)
+    @id = nil
+    @teams = teams
+  end
+
+  def team_medalists
+    @teams.map do |team|
+      {
+        team: team.name,
+        total_medal_count: team.total_medal_count,
+        medals: {
+          bronze: team.medal_count('Bronze'),
+          silver: team.medal_count('Silver'),
+          gold: team.medal_count('Gold')
+        }
+      }
+    end
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -13,7 +13,7 @@ class Olympian < ApplicationRecord
 
   def total_medal_count
     olympian_events
-    .where.not(medal: 0)
+    .merge(OlympianEvent.medalled_events)
     .count
   end
 
@@ -37,7 +37,7 @@ class Olympian < ApplicationRecord
   def self.event_medalists(event_id)
     select('olympians.*, olympian_events.medal AS medal')
     .joins(:events)
+    .merge(OlympianEvent.medalled_events)
     .where('events.id = ?', event_id)
-    .where.not('olympian_events.medal = ?', 0)
   end
 end

--- a/app/models/olympian_event.rb
+++ b/app/models/olympian_event.rb
@@ -5,4 +5,6 @@ class OlympianEvent < ApplicationRecord
   belongs_to :olympian
 
   enum medal: [ 'NA', 'Bronze', 'Silver', 'Gold' ]
+
+  scope :medalled_events, -> { where.not(medal: 0) }
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,4 +2,18 @@ class Team < ApplicationRecord
   validates :name, presence: true
 
   has_many :olympians
+
+  def total_medal_count
+    olympians
+    .joins(:events)
+    .merge(OlympianEvent.medalled_events)
+    .count
+  end
+
+  def medal_count(medal)
+    olympians
+    .joins(:events)
+    .where(olympian_events: { medal: medal })
+    .count
+  end
 end

--- a/app/serializers/medal_count_serializer.rb
+++ b/app/serializers/medal_count_serializer.rb
@@ -1,0 +1,7 @@
+class MedalCountSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :teams
+  set_id :id
+
+  attributes :team_medalists
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/events', to: 'events#index'
+      get '/medal_count', to: 'medal_count#index'
       get '/medalists', to: 'medalists#index'
       get '/olympians', to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#index'

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -8,4 +8,43 @@ RSpec.describe Team, type: :model do
   describe 'relationships' do
     it { should have_many :olympians }
   end
+
+  describe 'instance methods' do
+    before :each do
+      @t1 = create(:team)
+      @t2 = create(:team)
+
+      @o1 = create(:olympian, team: @t1)
+      @o2 = create(:olympian, team: @t1)
+      @o3 = create(:olympian, team: @t2)
+      @o4 = create(:olympian, team: @t2)
+
+      @e1 = create(:event, name: 'Event 1')
+      @e2 = create(:event, name: 'Event 2')
+      @e3 = create(:event, name: 'Event 3')
+      @e4 = create(:event, name: 'Event 4')
+
+      create(:olympian_event_with_medal, event: @e1, olympian: @o1, medal: 'Gold')
+      create(:olympian_event_with_medal, event: @e1, olympian: @o2, medal: 'Silver')
+      create(:olympian_event_with_medal, event: @e2, olympian: @o1, medal: 'Bronze')
+      create(:olympian_event_with_medal, event: @e2, olympian: @o2, medal: 'Bronze')
+      create(:olympian_event_with_medal, event: @e3, olympian: @o3, medal: 'Gold')
+      create(:olympian_event_with_medal, event: @e4, olympian: @o4, medal: 'Gold')
+    end
+
+    it '#total_medal_count' do
+      expect(@t1.total_medal_count).to eq(4)
+      expect(@t2.total_medal_count).to eq(2)
+    end
+
+    it '#medal_count' do
+      expect(@t1.medal_count('Bronze')).to eq(2)
+      expect(@t1.medal_count('Silver')).to eq(1)
+      expect(@t1.medal_count('Gold')).to eq(1)
+
+      expect(@t2.medal_count('Bronze')).to eq(0)
+      expect(@t2.medal_count('Silver')).to eq(0)
+      expect(@t2.medal_count('Gold')).to eq(2)
+    end
+  end
 end

--- a/spec/requests/api/v1/medal_count_endpoint_spec.rb
+++ b/spec/requests/api/v1/medal_count_endpoint_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'medal count endpoint' do
+  it 'returns medal counts for each team' do
+    t1 = create(:team)
+    t2 = create(:team)
+
+    o1 = create(:olympian, team: t1)
+    o2 = create(:olympian, team: t1)
+    o3 = create(:olympian, team: t2)
+    o4 = create(:olympian, team: t2)
+
+    e1 = create(:event, name: 'Event 1')
+    e2 = create(:event, name: 'Event 2')
+    e3 = create(:event, name: 'Event 3')
+    e4 = create(:event, name: 'Event 4')
+
+    create(:olympian_event_with_medal, event: e1, olympian: o1)
+    create(:olympian_event_with_medal, event: e1, olympian: o2)
+    create(:olympian_event_with_medal, event: e2, olympian: o1)
+    create(:olympian_event_with_medal, event: e2, olympian: o2)
+    create(:olympian_event_with_medal, event: e3, olympian: o3)
+    create(:olympian_event_with_medal, event: e4, olympian: o4)
+
+    get '/api/v1/medal_count'
+
+    teams = JSON.parse(response.body, symbolize_names: true)[:data][:attributes][:team_medalists]
+    team = teams[0]
+    team_medals = team[:medals]
+
+    expect(teams.count).to eq(2)
+
+    expect(team).to have_key(:team)
+    expect(team).to have_key(:total_medal_count)
+    expect(team_medals).to have_key(:bronze)
+    expect(team_medals).to have_key(:silver)
+    expect(team_medals).to have_key(:gold)
+  end
+end


### PR DESCRIPTION
This PR adds the `medals_count` endpoint, which returns all teams with their associated medal counts.

**Changes proposed in this pull request:**
* Adds OlympianEvent.medalled_events scope, refactors Olympian model to leverage it
* Adds Team#total_medal_count and #medal_count with specs
* Adds `medal_count` endpoint spec
* Adds MedalCountController#index and route
* Adds MedalCountFacade and Serializer
* Adds `medal_count` endpoint documentation to REAME

Resolves #12 

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)