### PR TITLE
User Can Fetch Sport Count by Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,60 @@ Example of expected response:
 }
 ```
 
+### `GET /api/v1/event_participation`
+
+Returns a list of teams with their total event participation.
+
+Example of expected response:
+```
+{
+  "data": {
+    "id": null,
+    "type": "team",
+    "attributes": {
+      "team_participation": [
+        {
+          "team": "Romania",
+          "event_participation": "29 of 305 events",
+          "percentage": 0.1,
+          "events": [
+            "Weightlifting Women's Super-Heavyweight",
+            "Rowing Men's Coxless Fours",
+            "Wrestling Men's Heavyweight, Greco-Roman",
+            "Athletics Women's 20 kilometres Walk",
+            "Handball Women's Handball",
+            "Tennis Women's Singles",
+            "Tennis Mixed Doubles",
+            "Tennis Women's Doubles",
+            "Rowing Women's Lightweight Double Sculls",
+            "Rowing Women's Coxless Pairs",
+            "Rowing Women's Coxed Eights",
+            "Athletics Women's 800 metres",
+            "Athletics Women's 3,000 metres Steeplechase",
+            "Fencing Women's epee, Individual",
+            "Fencing Women's epee, Team",
+            "Athletics Women's Triple Jump",
+            "Fencing Women's Foil, Individual",
+            "Judo Women's Lightweight",
+            "Weightlifting Men's Middleweight",
+            "Judo Women's Half-Lightweight",
+            "Athletics Women's Marathon",
+            "Athletics Men's 50 kilometres Walk",
+            "Swimming Men's 4 x 100 metres Freestyle Relay",
+            "Table Tennis Men's Singles",
+            "Swimming Women's 100 metres Freestyle",
+            "Fencing Men's Sabre, Individual",
+            "Gymnastics Men's Floor Exercise",
+            "Gymnastics Men's Horse Vault",
+            "Gymnastics Men's Horizontal Bar"
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/controllers/api/v1/event_participation_controller.rb
+++ b/app/controllers/api/v1/event_participation_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::EventParticipationController < ApplicationController
+  def index
+    teams = Team.all
+    facade = EventParticipationFacade.new(teams)
+    render json: EventParticipationSerializer.new(facade)
+  end
+end

--- a/app/facades/event_participation_facade.rb
+++ b/app/facades/event_participation_facade.rb
@@ -1,0 +1,19 @@
+class EventParticipationFacade
+  attr_reader :id
+
+  def initialize(teams)
+    @id = nil
+    @teams = teams
+  end
+
+  def team_participation
+    @teams.map do |team|
+      {
+        team: team.name,
+        event_participation: "#{Event.team_events(team.id).count} of #{Event.count} events",
+        percentage: Event.team_participation_percentage(team.id),
+        events: Event.team_events(team.id)
+      }
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,4 +4,16 @@ class Event < ApplicationRecord
   belongs_to :sport
   has_many :olympian_events
   has_many :olympians, through: :olympian_events
+
+  def self.team_participation_percentage(team_id)
+    (team_events(team_id).count).fdiv(self.count)
+  end
+
+  def self.team_events(team_id)
+    select('events.*')
+    .joins(olympians: :team)
+    .where(teams: { id: team_id })
+    .uniq
+    .pluck(:name)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ApplicationRecord
   has_many :olympians, through: :olympian_events
 
   def self.team_participation_percentage(team_id)
-    (team_events(team_id).count).fdiv(self.count)
+    (team_events(team_id).count).fdiv(self.count).round(2)
   end
 
   def self.team_events(team_id)

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -1,0 +1,7 @@
+class EventParticipationSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :team
+  set_id :id
+
+  attribute :team_participation
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      get '/event_participation', to: 'event_participation#index'
       get '/events', to: 'events#index'
       get '/medal_count', to: 'medal_count#index'
       get '/medalists', to: 'medalists#index'

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -11,4 +11,38 @@ RSpec.describe Event, type: :model do
     it { should have_many :olympian_events }
     it { should have_many(:olympians).through(:olympian_events) }
   end
+
+  describe 'class methods' do
+    before :each do
+      @t1 = create(:team)
+      @t2 = create(:team)
+
+      @o1 = create(:olympian, team: @t1)
+      @o2 = create(:olympian, team: @t1)
+      @o3 = create(:olympian, team: @t2)
+      @o4 = create(:olympian, team: @t2)
+
+      @e1 = create(:event, name: 'Event 1')
+      @e2 = create(:event, name: 'Event 2')
+      @e3 = create(:event, name: 'Event 3')
+      @e4 = create(:event, name: 'Event 4')
+
+      create(:olympian_event_with_medal, event: @e1, olympian: @o1)
+      create(:olympian_event_with_medal, event: @e1, olympian: @o2)
+      create(:olympian_event_with_medal, event: @e2, olympian: @o1)
+      create(:olympian_event_with_medal, event: @e2, olympian: @o2)
+      create(:olympian_event_with_medal, event: @e3, olympian: @o3)
+      create(:olympian_event_with_medal, event: @e4, olympian: @o1)
+    end
+
+    it '.team_participation_percentage' do
+      expect(Event.team_participation_percentage(@t1.id)).to eq(0.75)
+      expect(Event.team_participation_percentage(@t2.id)).to eq(0.25)
+    end
+
+    it '.team_events' do
+      expect(Event.team_events(@t1.id)).to eq(['Event 1', 'Event 2', 'Event 4'])
+      expect(Event.team_events(@t2.id)).to eq(['Event 3'])
+    end
+  end
 end

--- a/spec/requests/api/v1/event_participation_spec.rb
+++ b/spec/requests/api/v1/event_participation_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'event participation endpoint' do
+  it 'returns event participation for each team' do
+    t1 = create(:team)
+    t2 = create(:team)
+
+    o1 = create(:olympian, team: t1)
+    o2 = create(:olympian, team: t1)
+    o3 = create(:olympian, team: t2)
+    o4 = create(:olympian, team: t2)
+
+    e1 = create(:event, name: 'Event 1')
+    e2 = create(:event, name: 'Event 2')
+    e3 = create(:event, name: 'Event 3')
+    e4 = create(:event, name: 'Event 4')
+
+    create(:olympian_event_with_medal, event: e1, olympian: o1)
+    create(:olympian_event_with_medal, event: e1, olympian: o2)
+    create(:olympian_event_with_medal, event: e2, olympian: o1)
+    create(:olympian_event_with_medal, event: e2, olympian: o2)
+    create(:olympian_event_with_medal, event: e3, olympian: o3)
+    create(:olympian_event_with_medal, event: e4, olympian: o4)
+
+    get '/api/v1/event_participation'
+
+    teams = JSON.parse(response.body, symbolize_names: true)[:data][:attributes][:team_participation]
+    team = teams[0]
+    team_events = team[:events]
+
+    expect(teams.count).to eq(2)
+
+    expect(team).to have_key(:team)
+    expect(team).to have_key(:event_participation)
+    expect(team).to have_key(:percentage)
+    expect(team_events[0]).to eq('Event 1')
+    expect(team_events[1]).to eq('Event 2')
+  end
+end


### PR DESCRIPTION
This PR adds the `event_participation` endpoint, which returns teams with their participation information.

**Changes proposed in this pull request:**
* Adds `event_participation` endpoint request spec
* Adds EventParticipationController#index and route
* Adds Event.team_events and .team_participation_percentage with specs
* Adds EventParticipationFacade and Serializer
* Adds `event_participation` documentation to the README

Resolves #13, Resolve #5

**The following checks have been completed:**
* [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
* [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
* [x] Merged in the latest master to my branch with `git pull origin master` and resolved merge conflicts
* [x] Ran `rails db:migrate`
* [x] Ran the test suite - all tests are passing (or maybe skipped)
* [x] Checked affected endpoints in Postman
* [x] Updated README for changes (new endpoints, new gems, etc)
